### PR TITLE
105 fix webinterface to ignore late request completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ test_setup/
 
 # Burrito output
 /burrito_out/
+
+# OpenCode AI
+opencode.json

--- a/apps/manager/lib/saga/activate.ex
+++ b/apps/manager/lib/saga/activate.ex
@@ -121,7 +121,7 @@ defmodule Manager.Saga.Activate do
 
   # if we cannot get user orders, there is no point in continuing
   def handle_info({:get_user_orders, {:error, _reason}} = error, %{from: from} = state) do
-    send(from, {:activate, error})
+    send(from, {:activate, {:error, error}})
     {:stop, error, state}
   end
 
@@ -201,7 +201,7 @@ defmodule Manager.Saga.Activate do
   # if we miss on a item order list, we can still continue
   # the price will remain nil and be filtered later on
   def handle_info({:get_item_orders, {:error, _reason}} = error, %{from: from} = state) do
-    send(from, {:activate, error})
+    send(from, {:activate, {:error, error}})
     {:noreply, state}
   end
 
@@ -291,7 +291,7 @@ defmodule Manager.Saga.Activate do
 
   # if we fail to place an order, we can still continue with the others
   def handle_info({:place_order, {:error, _msg}} = error, %{from: from} = state) do
-    send(from, error)
+    send(from, {:activate, {:error, error}})
     {:noreply, state}
   end
 

--- a/apps/manager/lib/saga/activate.ex
+++ b/apps/manager/lib/saga/activate.ex
@@ -76,49 +76,26 @@ defmodule Manager.Saga.Activate do
   def handle_info(
         {:get_user_orders, {:ok, placed_orders}},
         %{
-          deps: %{store: store, auction_house: auction_house},
+          deps: %{store: store, auction_house: _auction_house},
           args: %{syndicates_with_strategy: syndicates_with_strategy},
           non_patreon_order_limit: limit,
           user: %User{patreon?: patreon?},
           from: from
         } = state
       ) do
-    products =
-      syndicates_with_strategy
-      |> Map.keys()
-      |> store.list_products()
+    with {:ok, total_products} <- list_relevant_products(syndicates_with_strategy, store),
+         order_number_limit = calculate_order_limit(placed_orders, total_products, limit, patreon?),
+         {:ok, updated_state} <- process_products(order_number_limit, total_products, state) do
+      send(from, {:activate, {:ok, :calculating_item_prices}})
+      {:noreply, updated_state}
+    else
+      {:error, :no_slots_free} ->
+        send(from, {:activate, {:ok, :no_slots_free}})
+        {:stop, :normal, state}
 
-    case products do
-      {:ok, total_products} ->
-        order_number_limit = calculate_order_limit(placed_orders, total_products, limit, patreon?)
-
-        if order_number_limit == 0 do
-          case store.deactivate_syndicates(Map.keys(syndicates_with_strategy)) do
-            :ok ->
-              send(from, {:activate, {:ok, :no_slots_free}})
-              {:stop, :normal, state}
-
-            {:error, _reason} = err ->
-              send(from, {:activate, {:error, {:failed_rollback_activation, err}}})
-              {:stop, err, state}
-          end
-        else
-          product_prices = initiate_product_prices(total_products)
-
-          updated_state =
-            state
-            |> Map.put(:total_products_count, length(total_products))
-            |> Map.put(:product_prices, product_prices)
-            |> Map.put(:order_number_limit, order_number_limit)
-
-          product_prices
-          |> Map.keys()
-          |> Enum.map(& &1.name)
-          |> Enum.each(&auction_house.get_item_orders/1)
-
-          send(from, {:activate, {:ok, :calculating_item_prices}})
-          {:noreply, updated_state}
-        end
+      {:error, {:failed_rollback_activation, err}} ->
+        send(from, {:activate, {:error, {:failed_rollback_activation, err}}})
+        {:stop, err, state}
 
       err ->
         send(from, {:activate, {:error, {:get_item_orders, err}}})
@@ -305,6 +282,55 @@ defmodule Manager.Saga.Activate do
   ###########
   # Private #
   ###########
+
+  @spec list_relevant_products(map(), module()) :: Store.Type.list_products_response()
+  defp list_relevant_products(syndicates_with_strategy, store) do
+    syndicates_with_strategy
+    |> Map.keys()
+    |> store.list_products()
+  end
+
+  @spec process_products(
+          non_neg_integer(),
+          [Product.t()],
+          %{
+            deps: Manager.Type.dependencies(),
+            args: %{syndicates_with_strategy: map()}
+          }
+        ) ::
+          {:ok, map()}
+          | {:error, :no_slots_free}
+          | {:error, {:failed_rollback_activation, Store.Type.deactivate_syndicates_response()}}
+
+  defp process_products(0, _total_products, %{
+         deps: %{store: store},
+         args: %{syndicates_with_strategy: syndicates_with_strategy}
+       }) do
+    case store.deactivate_syndicates(Map.keys(syndicates_with_strategy)) do
+      :ok ->
+        {:error, :no_slots_free}
+
+      {:error, _reason} = err ->
+        {:error, {:failed_rollback_activation, err}}
+    end
+  end
+
+  defp process_products(order_number_limit, total_products, %{deps: %{auction_house: auction_house}} = state) do
+    product_prices = initiate_product_prices(total_products)
+
+    updated_state =
+      state
+      |> Map.put(:total_products_count, length(total_products))
+      |> Map.put(:product_prices, product_prices)
+      |> Map.put(:order_number_limit, order_number_limit)
+
+    product_prices
+    |> Map.keys()
+    |> Enum.map(& &1.name)
+    |> Enum.each(&auction_house.get_item_orders/1)
+
+    {:ok, updated_state}
+  end
 
   @spec initiate_product_prices([Product.t()]) :: %{Product.t() => nil}
   defp initiate_product_prices(total_products) do

--- a/apps/manager/lib/saga/activate.ex
+++ b/apps/manager/lib/saga/activate.ex
@@ -294,14 +294,21 @@ defmodule Manager.Saga.Activate do
           non_neg_integer(),
           [Product.t()],
           %{
-            deps: Manager.Type.dependencies(),
-            args: %{syndicates_with_strategy: map()}
+            deps: %{
+              store: module(),
+              auction_house: module()
+            },
+            args: %{
+              syndicates_with_strategy: map()
+            },
+            from: pid(),
+            non_patreon_order_limit: pos_integer(),
+            user: User.t()
           }
         ) ::
           {:ok, map()}
           | {:error, :no_slots_free}
           | {:error, {:failed_rollback_activation, Store.Type.deactivate_syndicates_response()}}
-
   defp process_products(0, _total_products, %{
          deps: %{store: store},
          args: %{syndicates_with_strategy: syndicates_with_strategy}

--- a/apps/manager/lib/saga/activate.ex
+++ b/apps/manager/lib/saga/activate.ex
@@ -93,8 +93,15 @@ defmodule Manager.Saga.Activate do
         order_number_limit = calculate_order_limit(placed_orders, total_products, limit, patreon?)
 
         if order_number_limit == 0 do
-          send(from, {:activate, {:ok, :no_slots_free}})
-          {:stop, :normal, state}
+          case store.deactivate_syndicates(Map.keys(syndicates_with_strategy)) do
+            :ok ->
+              send(from, {:activate, {:ok, :no_slots_free}})
+              {:stop, :normal, state}
+
+            {:error, _reason} = err ->
+              send(from, {:activate, {:error, {:failed_rollback_activation, err}}})
+              {:stop, err, state}
+          end
         else
           product_prices = initiate_product_prices(total_products)
 

--- a/apps/manager/lib/saga/deactivate.ex
+++ b/apps/manager/lib/saga/deactivate.ex
@@ -90,7 +90,7 @@ defmodule Manager.Saga.Deactivate do
 
   # if we cannot get user orders, there is no point in continuing
   def handle_info({:get_user_orders, {:error, _reason}} = error, %{from: from} = state) do
-    send(from, {:activate, error})
+    send(from, {:deactivate, {:error, error}})
     {:stop, error, state}
   end
 
@@ -131,7 +131,7 @@ defmodule Manager.Saga.Deactivate do
 
   # if we fail to delete a placed order, we can still continue to delete the others
   def handle_info({:delete_order, {:error, _msg}} = error, %{from: from} = state) do
-    send(from, error)
+    send(from, {:deactivate, {:error, error}})
     {:noreply, state}
   end
 

--- a/apps/manager/test/unit/saga/activate_test.exs
+++ b/apps/manager/test/unit/saga/activate_test.exs
@@ -165,6 +165,11 @@ defmodule Manager.Saga.ActivateTest do
               expected_ids = Map.keys(syndicates_with_strategy)
               assert syndicate_ids == expected_ids
               {:ok, [Helpers.create_product(), Helpers.create_product(), Helpers.create_product()]}
+            end,
+            deactivate_syndicates: fn syndicate_ids ->
+              expected_ids = Map.keys(syndicates_with_strategy)
+              assert syndicate_ids == expected_ids
+              :ok
             end
           ]
         }
@@ -197,6 +202,60 @@ defmodule Manager.Saga.ActivateTest do
                   }}
 
         assert_receive({:activate, {:ok, :no_slots_free}}, @timeout)
+      end
+    end
+
+    test "sends :failed_rollback_activation messages if there is no place for more orders and activation rollback fails",
+         %{
+           syndicates_with_strategy: syndicates_with_strategy,
+           from: from,
+           user: user,
+           limit: limit
+         } do
+      with_mocks([
+        {
+          Store,
+          [],
+          [
+            list_products: fn syndicate_ids ->
+              expected_ids = Map.keys(syndicates_with_strategy)
+              assert syndicate_ids == expected_ids
+              {:ok, [Helpers.create_product(), Helpers.create_product(), Helpers.create_product()]}
+            end,
+            deactivate_syndicates: fn _syndicate_ids ->
+              {:error, :enoent}
+            end
+          ]
+        }
+      ]) do
+        placed_orders = [
+          Helpers.create_placed_order(),
+          Helpers.create_placed_order(),
+          Helpers.create_placed_order(),
+          Helpers.create_placed_order(),
+          Helpers.create_placed_order()
+        ]
+
+        assert Activate.handle_info(
+                 {:get_user_orders, {:ok, placed_orders}},
+                 %{
+                   deps: %{store: Store, auction_house: AuctionHouse},
+                   args: %{syndicates_with_strategy: syndicates_with_strategy},
+                   non_patreon_order_limit: limit,
+                   user: user,
+                   from: from
+                 }
+               ) ==
+                 {:stop, {:error, :enoent},
+                  %{
+                    args: %{syndicates_with_strategy: syndicates_with_strategy},
+                    user: user,
+                    deps: %{store: Store, auction_house: AuctionHouse},
+                    from: from,
+                    non_patreon_order_limit: limit
+                  }}
+
+        assert_receive({:activate, {:error, {:failed_rollback_activation, _}}}, @timeout)
       end
     end
 

--- a/apps/store/priv/products.json
+++ b/apps/store/priv/products.json
@@ -1641,7 +1641,7 @@
     "type": "mod"
   },
   {
-    "name": "Rythm Guard",
+    "name": "Rhythm Guard",
     "id": "6a33113c58b60af8cd1a0d26",
     "min_price": 14,
     "default_price": 16,

--- a/apps/web_interface/lib/web_interface/application.ex
+++ b/apps/web_interface/lib/web_interface/application.ex
@@ -15,32 +15,17 @@ defmodule WebInterface.Application do
   alias WebInterface.PubSub
   alias WebInterface.Telemetry
 
+  @typep env :: :dev | :test | :prod
+
   @impl true
   def start(_type, _args) do
-    children = [
-      Telemetry,
-      {Phoenix.PubSub, name: PubSub},
-      Endpoint,
-      Manager,
-      %{
-        id: Desktop.Window,
-        start:
-          {Desktop.Window, :start_link,
-           [
-             [
-               app: :web_interface,
-               id: WebInterface,
-               title: "Market Manager",
-               size: WindowUtils.calculate_window_size(0.6, 0.8),
-               menubar: MenuBar,
-               icon: "static/images/resized_logo_5_32x32.png",
-               url: &WebInterface.Endpoint.url/0
-             ]
-           ]},
-        restart: :transient,
-        shutdown: 5_000
-      }
-    ]
+    children =
+      [
+        Telemetry,
+        {Phoenix.PubSub, name: PubSub},
+        Endpoint,
+        Manager
+      ] ++ optional_children(fetch_env())
 
     opts = [strategy: :one_for_one, name: WebInterface.Supervisor]
 
@@ -63,5 +48,34 @@ defmodule WebInterface.Application do
   def config_change(changed, _new, removed) do
     WebInterface.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  @spec fetch_env :: env()
+  defp fetch_env, do: Application.fetch_env!(:web_interface, :env)
+
+  @spec optional_children(env()) :: [Supervisor.child_spec()]
+  defp optional_children(:test), do: []
+
+  defp optional_children(_) do
+    [
+      %{
+        id: Desktop.Window,
+        start:
+          {Desktop.Window, :start_link,
+           [
+             [
+               app: :web_interface,
+               id: WebInterface,
+               title: "Market Manager",
+               size: WindowUtils.calculate_window_size(0.6, 0.8),
+               menubar: MenuBar,
+               icon: "static/images/resized_logo_5_32x32.png",
+               url: &WebInterface.Endpoint.url/0
+             ]
+           ]},
+        restart: :transient,
+        shutdown: 5_000
+      }
+    ]
   end
 end

--- a/apps/web_interface/lib/web_interface/components/layouts/app.html.heex
+++ b/apps/web_interface/lib/web_interface/components/layouts/app.html.heex
@@ -58,16 +58,6 @@
                     <span class="sr-only">Open user menu</span>
                   </button>
                 </div>
-                <!--
-                Dropdown menu, show/hide based on menu state.
-
-                Entering: "transition ease-out duration-100"
-                  From: "transform opacity-0 scale-95"
-                  To: "transform opacity-100 scale-100"
-                Leaving: "transition ease-in duration-75"
-                  From: "transform opacity-100 scale-100"
-                  To: "transform opacity-0 scale-95"
-              -->
                 <div
                   class="hidden absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
                   role="menu"

--- a/apps/web_interface/lib/web_interface/live/activate_live.ex
+++ b/apps/web_interface/lib/web_interface/live/activate_live.ex
@@ -137,6 +137,23 @@ defmodule WebInterface.ActivateLive do
     {:noreply, assign(socket, message: "Activate: Getting user orders.")}
   end
 
+  def handle_info({:activate, {:ok, :no_slots_free}}, socket) do
+    updated_socket =
+      socket
+      |> assign(activation_in_progress: false)
+      |> assign(operation_in_progress?: false)
+      |> assign(message: nil)
+
+    Logger.info("Activate: No free order slots available.")
+
+    {:noreply,
+     put_flash(
+       updated_socket,
+       :info,
+       "No free order slots were available. No new orders were placed."
+     )}
+  end
+
   def handle_info({:activate, {:ok, :calculating_item_prices}}, socket) do
     Logger.info("Activate: Calculating item prices.")
     {:noreply, assign(socket, message: "Activate: Calculating item prices.")}

--- a/apps/web_interface/lib/web_interface/live/activate_live.ex
+++ b/apps/web_interface/lib/web_interface/live/activate_live.ex
@@ -200,7 +200,7 @@ defmodule WebInterface.ActivateLive do
     end
   end
 
-  # TODO: We treat every error as a fatal error, but we need to handle some errors as non-fatal, 
+  # TODO: We treat every error as a fatal error, but we need to handle some errors as non-fatal,
   # e.g., if we fail to place or get an order, we can still continue with the others
   def handle_info({:activate, {:error, reason}}, socket) do
     Logger.error("Activate: Error occurred - #{inspect(reason)}")

--- a/apps/web_interface/lib/web_interface/live/activate_live.ex
+++ b/apps/web_interface/lib/web_interface/live/activate_live.ex
@@ -38,7 +38,7 @@ defmodule WebInterface.ActivateLive do
     else
       error ->
         Logger.error("Unable to show deactivation page: #{inspect(error)}")
-        {:error, put_flash(socket, :error, "Unable to show deactivation page!")}
+        {:error, put_flash(socket, :error, "Unable to show activation page!")}
     end
   end
 
@@ -99,32 +99,9 @@ defmodule WebInterface.ActivateLive do
     end
   end
 
-  def handle_event(
-        "change",
-        %{"syndicates" => syndicate_ids, "strategies" => strategy_id},
-        socket
-      ) do
-    with {:ok, strategy} <- StrategyStore.get_strategy_by_id(strategy_id),
-         {:ok, syndicates} <- SyndicateStore.get_all_syndicates_by_id(syndicate_ids),
-         :ok <- StrategyStore.set_selected_strategy(strategy),
-         {:ok, active_syndicates} <- SyndicateStore.get_active_syndicates(),
-         new_selected_syndicates = Enum.uniq(syndicates ++ active_syndicates),
-         :ok <- SyndicateStore.set_selected_active_syndicates(new_selected_syndicates) do
-      {:noreply,
-       assign(socket,
-         selected_strategy: strategy,
-         selected_active_syndicates: new_selected_syndicates
-       )}
-    else
-      err ->
-        Logger.error("Unable to retrieve change data: #{inspect(err)}")
-        {:noreply, put_flash(socket, :error, "Unable to retrieve data!")}
-    end
-  end
-
   def handle_event(event, params, socket) do
     Logger.error("Event: #{inspect(event)} ; #{inspect(params)}")
-    {:noreply, socket}
+    {:noreply, put_flash(socket, :error, "Received unknown event #{inspect(event)}")}
   end
 
   ##################

--- a/apps/web_interface/lib/web_interface/live/activate_live.ex
+++ b/apps/web_interface/lib/web_interface/live/activate_live.ex
@@ -37,8 +37,8 @@ defmodule WebInterface.ActivateLive do
       {:ok, updated_socket}
     else
       error ->
-        Logger.error("Unable to show deactivation page: #{inspect(error)}")
-        {:error, put_flash(socket, :error, "Unable to show activation page!")}
+        Logger.error("Unable to show activation page: #{inspect(error)}")
+        {:error, put_flash(socket, :error, "Unable to show activation page! Please check the logs for details.")}
     end
   end
 
@@ -69,7 +69,7 @@ defmodule WebInterface.ActivateLive do
     else
       err ->
         Logger.error("Unable to retrieve data: #{inspect(err)}")
-        {:noreply, put_flash(socket, :error, "Unable to retrieve data!")}
+        {:noreply, put_flash(socket, :error, "Unable to perform activation! Please check the logs for details.")}
     end
   end
 
@@ -84,7 +84,7 @@ defmodule WebInterface.ActivateLive do
     else
       err ->
         Logger.error("Unable to retrieve syndicate data: #{inspect(err)}")
-        {:noreply, put_flash(socket, :error, "Unable to retrieve data!")}
+        {:noreply, put_flash(socket, :error, "Unable to perform activation! Please check the logs for details.")}
     end
   end
 

--- a/apps/web_interface/lib/web_interface/live/activate_live.ex
+++ b/apps/web_interface/lib/web_interface/live/activate_live.ex
@@ -200,6 +200,20 @@ defmodule WebInterface.ActivateLive do
     end
   end
 
+  # TODO: We treat every error as a fatal error, but we need to handle some errors as non-fatal, 
+  # e.g., if we fail to place or get an order, we can still continue with the others
+  def handle_info({:activate, {:error, reason}}, socket) do
+    Logger.error("Activate: Error occurred - #{inspect(reason)}")
+
+    updated_socket =
+      socket
+      |> assign(activation_in_progress: false)
+      |> assign(operation_in_progress?: false)
+      |> assign(message: nil)
+
+    {:noreply, put_flash(updated_socket, :error, "Activation failed, please check the logs for details.")}
+  end
+
   def handle_info(message, socket) do
     Logger.error("Unknown message received: #{inspect(message)}")
 

--- a/apps/web_interface/lib/web_interface/live/deactivate_live.ex
+++ b/apps/web_interface/lib/web_interface/live/deactivate_live.ex
@@ -201,117 +201,28 @@ defmodule WebInterface.DeactivateLive do
     end
   end
 
+  def handle_info({:activate, {:error, reason}}, socket) do
+    Logger.error("Deactivate: Reactivation error occurred - #{inspect(reason)}")
+
+     updated_socket =
+      socket
+      |> assign(deactivation_in_progress: false)
+      |> assign(operation_in_progress?: false)
+      |> assign(message: nil)
+
+      {:noreply,
+       put_flash(
+         updated_socket,
+         :error,
+         "The selected syndicates were deactivated, but reactivation of the remaining ones failed. Please check the logs for details."
+       )}
+  end
+
   def handle_info(message, socket) do
     Logger.error("Unknown message received: #{inspect(message)}")
 
     {:noreply, put_flash(socket, :error, "Something unexpected happened, please report it!")}
   end
-
-  # def handle_info({:deactivate, syndicate, {:error, reason} = error}, socket) do
-  #   Logger.error("Unable to deactivate syndicate #{syndicate.name}: #{inspect(error)}")
-
-  #   with {:ok, inactive_syndicates} <- SyndicateStore.get_inactive_syndicates(),
-  #        new_selected_syndicates = inactive_syndicates -- [syndicate],
-  #        :ok <- SyndicateStore.set_selected_inactive_syndicates(new_selected_syndicates) do
-  #     {:noreply,
-  #      put_flash(
-  #        assign(socket, operation_in_progress?: true),
-  #        :error,
-  #        "Unable to deactivate syndicate #{syndicate.name} due to '#{reason}'."
-  #      )}
-  #   else
-  #     err ->
-  #       Logger.error("Failed to retrieve persistence data: #{inspect(err)}")
-
-  #       {:noreply, put_flash(socket, :error, "Multiple errors ocurred, please check the logs.")}
-  #   end
-  # end
-
-  # def handle_info(
-  #       {:deactivate, syndicate, {current_item, total_items, {:error, reason, _item} = error}},
-  #       socket
-  #     ) do
-  #   Logger.error("Order deletion for item of #{syndicate.name} failed: #{inspect(error)}")
-
-  #   updated_socket =
-  #     socket
-  #     |> assign(deactivation_progress: round(current_item / total_items * 100))
-  #     |> put_flash(:error, "Unable to delete an order for #{syndicate.name} due to '#{reason}'.")
-
-  #   {:noreply, updated_socket}
-  # end
-
-  # def handle_info(
-  #       {:deactivate, syndicate, {current_item, total_items, {:ok, %Shared.Data.PlacedOrder{item_id: item_id}}}},
-  #       socket
-  #     ) do
-  #   Logger.info("Order deleted for #{syndicate.name}: #{item_id}")
-
-  #   {:noreply, assign(socket, deactivation_progress: round(current_item / total_items * 100))}
-  # end
-
-  # def handle_info({:deactivate, syndicate, :done}, socket) do
-  #   Logger.info("Deactivation of #{syndicate.name} complete.")
-
-  #   with {:ok, selected_syndicates} <- SyndicateStore.get_selected_inactive_syndicates(),
-  #        {:ok, inactive_syndicates} <- SyndicateStore.get_inactive_syndicates(),
-  #        {:ok, active_syndicates} <- Manager.active_syndicates(),
-  #        new_selected_syndicates =
-  #          Enum.uniq(selected_syndicates ++ inactive_syndicates),
-  #        :ok <- SyndicateStore.set_selected_inactive_syndicates(new_selected_syndicates) do
-  #     missing_syndicates =
-  #       selected_syndicates
-  #       |> MapSet.new()
-  #       |> MapSet.difference(MapSet.new(inactive_syndicates))
-  #       |> MapSet.to_list()
-  #       |> List.flatten()
-
-  #     to_assign =
-  #       if Enum.empty?(missing_syndicates) do
-  #         [deactivation_current_syndicate: nil, deactivation_in_progress: false, operation_in_progress?: false]
-  #       else
-  #         [next_syndicate | _rest] = missing_syndicates
-  #         :ok = Manager.deactivate(next_syndicate)
-  #         [deactivation_current_syndicate: next_syndicate, deactivation_progress: 0]
-  #       end
-
-  #     updated_socket =
-  #       socket
-  #       |> assign(inactive_syndicates: inactive_syndicates)
-  #       |> assign(selected_inactive_syndicates: new_selected_syndicates)
-  #       |> assign(to_assign)
-
-  #     # specially common in the case of timeouts from the auction house
-  #     partial_deactivation? =
-  #       Enum.find(active_syndicates, fn syn -> syn.id == syndicate.id end) != nil
-
-  #     updated_socket =
-  #       if partial_deactivation? do
-  #         Logger.info("Syndicate #{syndicate.name} was only partially deactivated. Try again later!")
-
-  #         put_flash(
-  #           updated_socket,
-  #           :info,
-  #           "Syndicate #{syndicate.name} was only partially deactivated. Try again later!"
-  #         )
-  #       else
-  #         :ok = SyndicateStore.deactivate_syndicate(syndicate)
-  #         updated_socket
-  #       end
-
-  #     {:noreply, updated_socket}
-  #   else
-  #     error ->
-  #       Logger.error("Unable complete syndicate deactivation: #{inspect(error)}")
-  #       {:noreply, socket |> put_flash(:error, "Unable complete syndicate deactivation!")}
-  #   end
-  # end
-
-  # def handle_info(message, socket) do
-  #   Logger.error("Unknown message received: #{inspect(message)}")
-
-  #   {:noreply, socket |> put_flash(:error, "Something unexpected happened, please report it!")}
-  # end
 
   ####################
   # Helper Functions #

--- a/apps/web_interface/lib/web_interface/live/deactivate_live.ex
+++ b/apps/web_interface/lib/web_interface/live/deactivate_live.ex
@@ -204,18 +204,18 @@ defmodule WebInterface.DeactivateLive do
   def handle_info({:activate, {:error, reason}}, socket) do
     Logger.error("Deactivate: Reactivation error occurred - #{inspect(reason)}")
 
-     updated_socket =
+    updated_socket =
       socket
       |> assign(deactivation_in_progress: false)
       |> assign(operation_in_progress?: false)
       |> assign(message: nil)
 
-      {:noreply,
-       put_flash(
-         updated_socket,
-         :error,
-         "The selected syndicates were deactivated, but reactivation of the remaining ones failed. Please check the logs for details."
-       )}
+    {:noreply,
+     put_flash(
+       updated_socket,
+       :error,
+       "The selected syndicates were deactivated, but reactivation of the remaining ones failed. Please check the logs for details."
+     )}
   end
 
   def handle_info(message, socket) do

--- a/apps/web_interface/lib/web_interface/live/login_live.ex
+++ b/apps/web_interface/lib/web_interface/live/login_live.ex
@@ -100,9 +100,10 @@ defmodule WebInterface.LoginLive do
   end
 
   def handle_info(message, socket) do
-    socket
-    |> assign(logging_in: false)
-    |> put_flash(:error, "Unknown message received, please check the logs and report it!")
+    socket =
+      socket
+      |> assign(logging_in: false)
+      |> put_flash(:error, "Unknown message received, please check the logs and report it!")
 
     Logger.error("Unknown message received: #{inspect(message)}")
     {:noreply, socket}

--- a/apps/web_interface/mix.exs
+++ b/apps/web_interface/mix.exs
@@ -66,6 +66,9 @@ defmodule WebInterface.MixProject do
       {:desktop, "~> 1.5"},
       {:ets, "~> 0.9.0"},
 
+      # Testing and Dev
+      {:mock, "~> 0.3.0", only: [:dev, :test]},
+
       # Umbrella deps
       {:manager, in_umbrella: true},
       {:shared, in_umbrella: true}

--- a/apps/web_interface/test/web_interface/live/activate_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/activate_live_test.exs
@@ -6,11 +6,11 @@ defmodule WebInterface.ActivateLiveTest do
   import Phoenix.LiveViewTest
   import Mock
 
+  alias Manager
   alias Shared.Data.{Strategy, Syndicate, User}
   alias WebInterface.Persistence.Strategy, as: StrategyStore
   alias WebInterface.Persistence.Syndicate, as: SyndicateStore
   alias WebInterface.Persistence.User, as: UserStore
-  alias Manager
 
   setup do
     user = User.new(ingame_name: "Fl4m3", slug: "fl4m3", patreon?: false)

--- a/apps/web_interface/test/web_interface/live/activate_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/activate_live_test.exs
@@ -12,44 +12,87 @@ defmodule WebInterface.ActivateLiveTest do
   alias WebInterface.Persistence.User, as: UserStore
   alias Manager
 
-  describe "frontend events" do
-    test "it executes activate command when button is pressed", %{conn: conn} do
-      user = User.new(ingame_name: "Fl4m3", slug: "fl4m3", patreon?: false)
+  setup do
+    user = User.new(ingame_name: "Fl4m3", slug: "fl4m3", patreon?: false)
 
-      strategy =
+    strategies =
+      [
+        Strategy.new(
+          name: "Top 3 Average",
+          id: :top_three_average,
+          description: "Gets the 3 lowest prices for the given item and calculates the average."
+        ),
+        Strategy.new(
+          name: "Top 5 Average",
+          id: :top_five_average,
+          description: "Gets the 5 lowest prices for the given item and calculates the average."
+        ),
+        Strategy.new(
+          name: "Equal to lowest",
+          id: :equal_to_lowest,
+          description: "Gets the lowest price for the given item and uses it."
+        ),
         Strategy.new(
           name: "Lowest minus one",
           id: :lowest_minus_one,
-          description: "Undercut the lowest visible price by one platinum."
+          description: "Gets the lowest price for the given item and beats it by 1."
         )
+      ]
 
-      syndicate =
-        Syndicate.new(
-          name: "Steel Meridian",
-          id: :steel_meridian,
-          catalog: []
-        )
+    syndicates =
+      [
+        Syndicate.new(name: "Arbiters of Hexis", id: :arbiters_of_hexis, catalog: []),
+        Syndicate.new(name: "Arbitrations", id: :arbitrations, catalog: []),
+        Syndicate.new(name: "Cephalon Simaris", id: :cephalon_simaris, catalog: []),
+        Syndicate.new(name: "Cephalon Suda", id: :cephalon_suda, catalog: []),
+        Syndicate.new(name: "New Loka", id: :new_loka, catalog: []),
+        Syndicate.new(name: "Perrin Sequence", id: :perrin_sequence, catalog: []),
+        Syndicate.new(name: "Red Veil", id: :red_veil, catalog: []),
+        Syndicate.new(name: "Steel Meridian", id: :steel_meridian, catalog: [])
+      ]
 
-      strategy_id = Atom.to_string(strategy.id)
-      syndicate_id = Atom.to_string(syndicate.id)
+    %{user: user, strategies: strategies, syndicates: syndicates}
+  end
 
+  describe "frontend events" do
+    test "it executes activate command when button is pressed", %{
+      conn: conn,
+      user: user,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
       with_mocks([
         {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
         {StrategyStore, [],
          [
-           get_strategies: fn -> {:ok, [strategy]} end,
-           get_selected_strategy: fn -> {:ok, strategy} end,
-           get_strategy_by_id: fn _id -> {:ok, strategy} end
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn ->
+             {:ok, Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)}
+           end,
+           get_strategy_by_id: fn id ->
+             strategies
+             |> Enum.find(&(&1.id == String.to_existing_atom(id)))
+             |> then(&{:ok, &1})
+           end
          ]},
         {SyndicateStore, [],
          [
-           get_syndicates: fn -> {:ok, [syndicate]} end,
+           get_syndicates: fn -> {:ok, syndicates} end,
            get_active_syndicates: fn -> {:ok, []} end,
-           get_selected_active_syndicates: fn -> {:ok, [syndicate]} end,
-           get_all_syndicates_by_id: fn _ids -> {:ok, [syndicate]} end
+           get_selected_active_syndicates: fn ->
+             {:ok, Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)}
+           end,
+           get_all_syndicates_by_id: fn ids ->
+             syndicates
+             |> Enum.filter(fn syndicate -> syndicate.id in Enum.map(ids, &String.to_existing_atom/1) end)
+             |> then(&{:ok, &1})
+           end
          ]},
         {Manager, [], [activate: fn _params -> :ok end]}
       ]) do
+        strategy_id = Atom.to_string(:lowest_minus_one)
+        syndicate_id = Atom.to_string(:steel_meridian)
+
         {:ok, view, _html} = live(conn, ~p"/activate")
 
         html =
@@ -71,6 +114,111 @@ defmodule WebInterface.ActivateLiveTest do
 
         assert_called(Manager.activate(%{steel_meridian: :lowest_minus_one}))
         assert html =~ "Activation in progress..."
+      end
+    end
+
+    test "it changes syndicates correctly", %{
+      conn: conn,
+      user: user,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      active_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :red_veil end)
+
+      with_mocks([
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, nil} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, active_syndicates} end,
+           get_selected_active_syndicates: fn -> {:ok, []} end,
+           get_all_syndicates_by_id: fn ids ->
+             syndicates
+             |> Enum.filter(fn syndicate -> syndicate.id in Enum.map(ids, &String.to_existing_atom/1) end)
+             |> then(&{:ok, &1})
+           end,
+           set_selected_active_syndicates: fn _syndicates -> :ok end
+         ]}
+      ]) do
+        change_selected_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)
+        change_syndicate_ids = Enum.map(change_selected_syndicates, fn syndicate -> Atom.to_string(syndicate.id) end)
+
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        view
+        |> form("form", %{"syndicates" => change_syndicate_ids})
+        |> render_change(%{_target: ["syndicates"]})
+
+        assert_called(UserStore.get_user())
+        assert_called(UserStore.has_user?())
+
+        assert_called(StrategyStore.get_strategies())
+        assert_called(StrategyStore.get_selected_strategy())
+
+        assert_called(SyndicateStore.get_syndicates())
+        assert_called(SyndicateStore.get_active_syndicates())
+        assert_called(SyndicateStore.get_selected_active_syndicates())
+        assert_called(SyndicateStore.get_all_syndicates_by_id(change_syndicate_ids))
+        assert_called(SyndicateStore.set_selected_active_syndicates(change_selected_syndicates ++ active_syndicates))
+
+        assert has_element?(view, "input#steel_meridian[checked]")
+        assert has_element?(view, "input#red_veil[checked][disabled]")
+      end
+    end
+
+    test "it changes strategy correctly", %{
+      conn: conn,
+      user: user,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      with_mocks([
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, nil} end,
+           get_strategy_by_id: fn id ->
+             strategies
+             |> Enum.find(&(&1.id == String.to_existing_atom(id)))
+             |> then(&{:ok, &1})
+           end,
+           set_selected_strategy: fn _strategy -> :ok end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, []} end
+         ]}
+      ]) do
+        strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+        change_strategy_id = Atom.to_string(:lowest_minus_one)
+
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        view
+        |> form("form", %{"strategy" => change_strategy_id})
+        |> render_change()
+
+        assert_called(UserStore.get_user())
+        assert_called(UserStore.has_user?())
+
+        assert_called(SyndicateStore.get_syndicates())
+        assert_called(SyndicateStore.get_active_syndicates())
+        assert_called(SyndicateStore.get_selected_active_syndicates())
+
+        assert_called(StrategyStore.get_strategies())
+        assert_called(StrategyStore.get_selected_strategy())
+        assert_called(StrategyStore.get_strategy_by_id(change_strategy_id))
+        assert_called(StrategyStore.set_selected_strategy(strategy))
+
+        assert has_element?(view, "input#lowest_minus_one[checked]")
       end
     end
   end

--- a/apps/web_interface/test/web_interface/live/activate_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/activate_live_test.exs
@@ -56,9 +56,12 @@ defmodule WebInterface.ActivateLiveTest do
   end
 
   describe "frontend events" do
-    setup_with_mocks([
-      {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]}
-    ], %{user: user}) do
+    setup_with_mocks(
+      [
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]}
+      ],
+      %{user: user}
+    ) do
       :ok
     end
 
@@ -152,7 +155,7 @@ defmodule WebInterface.ActivateLiveTest do
 
         assert_not_called(SyndicateStore.get_all_syndicates_by_id(:_))
         assert_not_called(Manager.activate(:_))
-        
+
         assert render(view) =~ "Unable to perform activation! Please check the logs for details."
         assert log =~ "Unable to retrieve data: {:error, :not_found}"
       end
@@ -194,6 +197,7 @@ defmodule WebInterface.ActivateLiveTest do
         |> render_change(%{_target: ["syndicates"]})
 
         assert_called_exactly(SyndicateStore.get_all_syndicates_by_id(change_syndicate_ids), 1)
+
         assert_called_exactly(
           SyndicateStore.set_selected_active_syndicates(change_selected_syndicates ++ active_syndicates),
           1
@@ -227,7 +231,7 @@ defmodule WebInterface.ActivateLiveTest do
          ]}
       ]) do
         change_syndicate_ids = [Atom.to_string(:steel_meridian)]
-        
+
         {:ok, view, _html} = live(conn, ~p"/activate")
 
         log =
@@ -374,9 +378,12 @@ defmodule WebInterface.ActivateLiveTest do
   end
 
   describe "Execute button state" do
-    setup_with_mocks([
-      {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]}
-    ], %{user: user}) do
+    setup_with_mocks(
+      [
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]}
+      ],
+      %{user: user}
+    ) do
       :ok
     end
 

--- a/apps/web_interface/test/web_interface/live/activate_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/activate_live_test.exs
@@ -3,6 +3,7 @@ defmodule WebInterface.ActivateLiveTest do
 
   use WebInterface.ConnCase, async: false
 
+  import ExUnit.CaptureLog
   import Phoenix.LiveViewTest
   import Mock
 
@@ -55,14 +56,18 @@ defmodule WebInterface.ActivateLiveTest do
   end
 
   describe "frontend events" do
+    setup_with_mocks([
+      {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]}
+    ], %{user: user}) do
+      :ok
+    end
+
     test "it executes activate command when button is pressed", %{
       conn: conn,
-      user: user,
       strategies: strategies,
       syndicates: syndicates
     } do
       with_mocks([
-        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
         {StrategyStore, [],
          [
            get_strategies: fn -> {:ok, strategies} end,
@@ -100,33 +105,67 @@ defmodule WebInterface.ActivateLiveTest do
           |> form("form", %{"strategy" => strategy_id, "syndicates" => [syndicate_id]})
           |> render_submit()
 
-        assert_called(UserStore.get_user())
-        assert_called(UserStore.has_user?())
-
-        assert_called(StrategyStore.get_strategies())
-        assert_called(StrategyStore.get_selected_strategy())
-        assert_called(StrategyStore.get_strategy_by_id(strategy_id))
-
-        assert_called(SyndicateStore.get_syndicates())
-        assert_called(SyndicateStore.get_active_syndicates())
-        assert_called(SyndicateStore.get_selected_active_syndicates())
-        assert_called(SyndicateStore.get_all_syndicates_by_id([syndicate_id]))
-
-        assert_called(Manager.activate(%{steel_meridian: :lowest_minus_one}))
+        assert_called_exactly(StrategyStore.get_strategy_by_id(strategy_id), 1)
+        assert_called_exactly(SyndicateStore.get_all_syndicates_by_id([syndicate_id]), 1)
+        assert_called_exactly(Manager.activate(%{steel_meridian: :lowest_minus_one}), 1)
         assert html =~ "Activation in progress..."
+      end
+    end
+
+    test "it shows error if execute fails", %{
+      conn: conn,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      with_mocks([
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn ->
+             {:ok, Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)}
+           end,
+           get_strategy_by_id: fn _id -> {:error, :not_found} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn ->
+             {:ok, Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)}
+           end
+         ]},
+        {Manager, [], [activate: fn _params -> :ok end]}
+      ]) do
+        strategy_id = Atom.to_string(:lowest_minus_one)
+        syndicate_id = Atom.to_string(:steel_meridian)
+
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        log =
+          capture_log(fn ->
+            view
+            |> form("form", %{"strategy" => strategy_id, "syndicates" => [syndicate_id]})
+            |> render_submit()
+          end)
+
+        assert_called_exactly(StrategyStore.get_strategy_by_id(strategy_id), 1)
+
+        assert_not_called(SyndicateStore.get_all_syndicates_by_id(:_))
+        assert_not_called(Manager.activate(:_))
+        
+        assert render(view) =~ "Unable to retrieve data!"
+        assert log =~ "Unable to retrieve data: {:error, :not_found}"
       end
     end
 
     test "it changes syndicates correctly", %{
       conn: conn,
-      user: user,
       strategies: strategies,
       syndicates: syndicates
     } do
       active_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :red_veil end)
 
       with_mocks([
-        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
         {StrategyStore, [],
          [
            get_strategies: fn -> {:ok, strategies} end,
@@ -154,31 +193,67 @@ defmodule WebInterface.ActivateLiveTest do
         |> form("form", %{"syndicates" => change_syndicate_ids})
         |> render_change(%{_target: ["syndicates"]})
 
-        assert_called(UserStore.get_user())
-        assert_called(UserStore.has_user?())
-
-        assert_called(StrategyStore.get_strategies())
-        assert_called(StrategyStore.get_selected_strategy())
-
-        assert_called(SyndicateStore.get_syndicates())
-        assert_called(SyndicateStore.get_active_syndicates())
-        assert_called(SyndicateStore.get_selected_active_syndicates())
-        assert_called(SyndicateStore.get_all_syndicates_by_id(change_syndicate_ids))
-        assert_called(SyndicateStore.set_selected_active_syndicates(change_selected_syndicates ++ active_syndicates))
+        assert_called_exactly(SyndicateStore.get_all_syndicates_by_id(change_syndicate_ids), 1)
+        assert_called_exactly(
+          SyndicateStore.set_selected_active_syndicates(change_selected_syndicates ++ active_syndicates),
+          1
+        )
 
         assert has_element?(view, "input#steel_meridian[checked]")
         assert has_element?(view, "input#red_veil[checked][disabled]")
       end
     end
 
+    test "it shows error if changing syndicates fails", %{
+      conn: conn,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :perrin_sequence end)
+
+      with_mocks([
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, nil} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, selected_syndicates} end,
+           get_all_syndicates_by_id: fn _ids -> {:error, :not_found} end,
+           set_selected_active_syndicates: fn _syndicates -> :ok end
+         ]}
+      ]) do
+        change_syndicate_ids = [Atom.to_string(:steel_meridian)]
+        
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        log =
+          capture_log(fn ->
+            view
+            |> form("form", %{"syndicates" => change_syndicate_ids})
+            |> render_change(%{_target: ["syndicates"]})
+          end)
+
+        assert_called_exactly(SyndicateStore.get_all_syndicates_by_id(change_syndicate_ids), 1)
+        assert_not_called(SyndicateStore.set_selected_active_syndicates(:_))
+
+        assert render(view) =~ "Unable to retrieve data!"
+        assert log =~ "Unable to retrieve syndicate data: {:error, :not_found}"
+
+        assert has_element?(view, "input#perrin_sequence[checked]")
+        refute has_element?(view, "input#steel_meridian[checked]")
+      end
+    end
+
     test "it changes strategy correctly", %{
       conn: conn,
-      user: user,
       strategies: strategies,
       syndicates: syndicates
     } do
       with_mocks([
-        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
         {StrategyStore, [],
          [
            get_strategies: fn -> {:ok, strategies} end,
@@ -206,23 +281,95 @@ defmodule WebInterface.ActivateLiveTest do
         |> form("form", %{"strategy" => change_strategy_id})
         |> render_change()
 
-        assert_called(UserStore.get_user())
-        assert_called(UserStore.has_user?())
-
-        assert_called(SyndicateStore.get_syndicates())
-        assert_called(SyndicateStore.get_active_syndicates())
-        assert_called(SyndicateStore.get_selected_active_syndicates())
-
-        assert_called(StrategyStore.get_strategies())
-        assert_called(StrategyStore.get_selected_strategy())
-        assert_called(StrategyStore.get_strategy_by_id(change_strategy_id))
-        assert_called(StrategyStore.set_selected_strategy(strategy))
+        assert_called_exactly(StrategyStore.get_strategy_by_id(change_strategy_id), 1)
+        assert_called_exactly(StrategyStore.set_selected_strategy(strategy), 1)
 
         assert has_element?(view, "input#lowest_minus_one[checked]")
+      end
+    end
+
+    test "it shows error if changing strategy fails", %{
+      conn: conn,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :top_three_average end)
+
+      with_mocks([
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end,
+           get_strategy_by_id: fn _id -> {:error, :not_found} end,
+           set_selected_strategy: fn _strategy -> :ok end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, []} end
+         ]}
+      ]) do
+        change_strategy_id = Atom.to_string(:lowest_minus_one)
+
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        log =
+          capture_log(fn ->
+            view
+            |> form("form", %{"strategy" => change_strategy_id})
+            |> render_change(%{_target: ["strategy"]})
+          end)
+
+        assert_called_exactly(StrategyStore.get_strategy_by_id(change_strategy_id), 1)
+        assert_not_called(StrategyStore.set_selected_strategy(:_))
+
+        assert render(view) =~ "Unable to retrieve data!"
+        assert log =~ "Unable to retrieve strategy data: {:error, :not_found}"
+
+        assert has_element?(view, "input#top_three_average[checked]")
+        refute has_element?(view, "input#lowest_minus_one[checked]")
       end
     end
   end
 
   describe "backend events" do
+    test "it loads activation data on mount", %{
+      conn: conn,
+      user: user,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+      active_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :red_veil end)
+
+      with_mocks([
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, active_syndicates} end,
+           get_selected_active_syndicates: fn -> {:ok, active_syndicates} end
+         ]}
+      ]) do
+        {:ok, _view, html} = live(conn, ~p"/activate")
+
+        assert_called(UserStore.get_user())
+        assert_called(UserStore.has_user?())
+        assert_called(StrategyStore.get_strategies())
+        assert_called(StrategyStore.get_selected_strategy())
+        assert_called(SyndicateStore.get_syndicates())
+        assert_called(SyndicateStore.get_active_syndicates())
+        assert_called(SyndicateStore.get_selected_active_syndicates())
+
+        assert html =~ "Activating a syndicate will cause the app to create a sell order"
+        assert html =~ "Execute Command"
+      end
+    end
   end
 end

--- a/apps/web_interface/test/web_interface/live/activate_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/activate_live_test.exs
@@ -1,0 +1,80 @@
+defmodule WebInterface.ActivateLiveTest do
+  @moduledoc false
+
+  use WebInterface.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mock
+
+  alias Shared.Data.{Strategy, Syndicate, User}
+  alias WebInterface.Persistence.Strategy, as: StrategyStore
+  alias WebInterface.Persistence.Syndicate, as: SyndicateStore
+  alias WebInterface.Persistence.User, as: UserStore
+  alias Manager
+
+  describe "frontend events" do
+    test "it executes activate command when button is pressed", %{conn: conn} do
+      user = User.new(ingame_name: "Fl4m3", slug: "fl4m3", patreon?: false)
+
+      strategy =
+        Strategy.new(
+          name: "Lowest minus one",
+          id: :lowest_minus_one,
+          description: "Undercut the lowest visible price by one platinum."
+        )
+
+      syndicate =
+        Syndicate.new(
+          name: "Steel Meridian",
+          id: :steel_meridian,
+          catalog: []
+        )
+
+      strategy_id = Atom.to_string(strategy.id)
+      syndicate_id = Atom.to_string(syndicate.id)
+
+      with_mocks([
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, [strategy]} end,
+           get_selected_strategy: fn -> {:ok, strategy} end,
+           get_strategy_by_id: fn _id -> {:ok, strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, [syndicate]} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, [syndicate]} end,
+           get_all_syndicates_by_id: fn _ids -> {:ok, [syndicate]} end
+         ]},
+        {Manager, [], [activate: fn _params -> :ok end]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        html =
+          view
+          |> form("form", %{"strategy" => strategy_id, "syndicates" => [syndicate_id]})
+          |> render_submit()
+
+        assert_called(UserStore.get_user())
+        assert_called(UserStore.has_user?())
+
+        assert_called(StrategyStore.get_strategies())
+        assert_called(StrategyStore.get_selected_strategy())
+        assert_called(StrategyStore.get_strategy_by_id(strategy_id))
+
+        assert_called(SyndicateStore.get_syndicates())
+        assert_called(SyndicateStore.get_active_syndicates())
+        assert_called(SyndicateStore.get_selected_active_syndicates())
+        assert_called(SyndicateStore.get_all_syndicates_by_id([syndicate_id]))
+
+        assert_called(Manager.activate(%{steel_meridian: :lowest_minus_one}))
+        assert html =~ "Activation in progress..."
+      end
+    end
+  end
+
+  describe "backend events" do
+  end
+end

--- a/apps/web_interface/test/web_interface/live/activate_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/activate_live_test.exs
@@ -375,6 +375,146 @@ defmodule WebInterface.ActivateLiveTest do
         assert html =~ "Execute Command"
       end
     end
+
+    test "it updates the activation status and progress while backend messages arrive", %{
+      conn: conn,
+      user: user,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+      selected_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)
+
+      with_mocks([
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end,
+           get_strategy_by_id: fn _strategy_id -> {:ok, selected_strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, []} end,
+           get_all_syndicates_by_id: fn _syndicate_ids -> {:ok, selected_syndicates} end
+         ]},
+        {Manager, [], [activate: fn _params -> :ok end]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        view
+        |> form("form", %{"strategy" => "lowest_minus_one", "syndicates" => ["steel_meridian"]})
+        |> render_submit()
+
+        send(view.pid, {:activate, {:ok, :get_user_orders}})
+
+        assert has_element?(view, "p", "Activate: Getting user orders.")
+
+        send(view.pid, {:activate, {:ok, :calculating_item_prices}})
+
+        assert has_element?(view, "p", "Activate: Calculating item prices.")
+
+        send(view.pid, {:activate, {:ok, {:price_calculated, "Rift Haven", 42, 1, 4}}})
+
+        assert has_element?(view, "span", "25")
+
+        send(view.pid, {:activate, {:ok, :placing_orders}})
+
+        assert has_element?(view, "p", "Activate: Placing orders.")
+
+        send(view.pid, {:activate, {:ok, {:order_placed, "Rift Haven", 3, 4}}})
+
+        assert has_element?(view, "span", "75")
+      end
+    end
+
+    test "it persists activated syndicates and returns to the form when activation completes", %{
+      conn: conn,
+      user: user,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+      selected_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)
+
+      with_mocks([
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end,
+           get_strategy_by_id: fn _strategy_id -> {:ok, selected_strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, selected_syndicates} end,
+           get_all_syndicates_by_id: fn _syndicate_ids -> {:ok, selected_syndicates} end,
+           activate_syndicates: fn _syndicates_to_activate -> :ok end,
+           all_syndicates_active?: fn -> {:ok, false} end
+         ]},
+        {Manager, [], [activate: fn _params -> :ok end]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        view
+        |> form("form", %{"strategy" => "lowest_minus_one", "syndicates" => ["steel_meridian"]})
+        |> render_submit()
+
+        send(view.pid, {:activate, {:ok, :done}})
+
+        assert has_element?(view, "button", "Execute Command")
+        assert has_element?(view, "input#steel_meridian[checked]")
+        refute has_element?(view, "p", "Activation in progress...")
+        assert_called(Manager.activate(%{steel_meridian: :lowest_minus_one}))
+        assert_called(SyndicateStore.activate_syndicates(selected_syndicates))
+        assert_called(SyndicateStore.all_syndicates_active?())
+      end
+    end
+
+    @tag :capture_log
+    test "it resets the view and shows a flash when activation fails", %{
+      conn: conn,
+      user: user,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+      selected_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)
+
+      with_mocks([
+        {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]},
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end,
+           get_strategy_by_id: fn _strategy_id -> {:ok, selected_strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, selected_syndicates} end,
+           get_all_syndicates_by_id: fn _syndicate_ids -> {:ok, selected_syndicates} end
+         ]},
+        {Manager, [], [activate: fn _params -> :ok end]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        view
+        |> form("form", %{"strategy" => "lowest_minus_one", "syndicates" => ["steel_meridian"]})
+        |> render_submit()
+
+        send(view.pid, {:activate, {:error, :timeout}})
+
+        assert has_element?(view, "button", "Execute Command")
+        assert render(view) =~ "Activation failed, please check the logs for details."
+        refute has_element?(view, "p", "Activation in progress...")
+      end
+    end
   end
 
   describe "Execute button state" do

--- a/apps/web_interface/test/web_interface/live/activate_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/activate_live_test.exs
@@ -153,7 +153,7 @@ defmodule WebInterface.ActivateLiveTest do
         assert_not_called(SyndicateStore.get_all_syndicates_by_id(:_))
         assert_not_called(Manager.activate(:_))
         
-        assert render(view) =~ "Unable to retrieve data!"
+        assert render(view) =~ "Unable to perform activation! Please check the logs for details."
         assert log =~ "Unable to retrieve data: {:error, :not_found}"
       end
     end
@@ -240,7 +240,7 @@ defmodule WebInterface.ActivateLiveTest do
         assert_called_exactly(SyndicateStore.get_all_syndicates_by_id(change_syndicate_ids), 1)
         assert_not_called(SyndicateStore.set_selected_active_syndicates(:_))
 
-        assert render(view) =~ "Unable to retrieve data!"
+        assert render(view) =~ "Unable to perform activation! Please check the logs for details."
         assert log =~ "Unable to retrieve syndicate data: {:error, :not_found}"
 
         assert has_element?(view, "input#perrin_sequence[checked]")
@@ -369,6 +369,124 @@ defmodule WebInterface.ActivateLiveTest do
 
         assert html =~ "Activating a syndicate will cause the app to create a sell order"
         assert html =~ "Execute Command"
+      end
+    end
+  end
+
+  describe "Execute button state" do
+    setup_with_mocks([
+      {UserStore, [], [get_user: fn -> {:ok, user} end, has_user?: fn -> true end]}
+    ], %{user: user}) do
+      :ok
+    end
+
+    test "it disables execute button when no strategy is selected", %{
+      conn: conn,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)
+
+      with_mocks([
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, nil} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, selected_syndicates} end
+         ]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        assert has_element?(view, "button[disabled]", "Execute Command")
+      end
+    end
+
+    test "it disables execute button when no syndicates are selected", %{
+      conn: conn,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+
+      with_mocks([
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, []} end,
+           get_selected_active_syndicates: fn -> {:ok, []} end
+         ]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        assert has_element?(view, "button[disabled]", "Execute Command")
+      end
+    end
+
+    test "it disables execute button when selected syndicates are already active", %{
+      conn: conn,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+      active_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :steel_meridian end)
+
+      with_mocks([
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, active_syndicates} end,
+           get_selected_active_syndicates: fn -> {:ok, active_syndicates} end
+         ]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        assert has_element?(view, "button[disabled]", "Execute Command")
+      end
+    end
+
+    test "it enables execute button when strategy and inactive selected syndicate are present", %{
+      conn: conn,
+      strategies: strategies,
+      syndicates: syndicates
+    } do
+      selected_strategy = Enum.find(strategies, fn strategy -> strategy.id == :lowest_minus_one end)
+      active_syndicates = Enum.filter(syndicates, fn syndicate -> syndicate.id == :red_veil end)
+
+      selected_syndicates =
+        Enum.filter(syndicates, fn syndicate -> syndicate.id in [:red_veil, :steel_meridian] end)
+
+      with_mocks([
+        {StrategyStore, [],
+         [
+           get_strategies: fn -> {:ok, strategies} end,
+           get_selected_strategy: fn -> {:ok, selected_strategy} end
+         ]},
+        {SyndicateStore, [],
+         [
+           get_syndicates: fn -> {:ok, syndicates} end,
+           get_active_syndicates: fn -> {:ok, active_syndicates} end,
+           get_selected_active_syndicates: fn -> {:ok, selected_syndicates} end
+         ]}
+      ]) do
+        {:ok, view, _html} = live(conn, ~p"/activate")
+
+        assert has_element?(view, "button", "Execute Command")
+        refute has_element?(view, "button[disabled]", "Execute Command")
       end
     end
   end

--- a/apps/web_interface/test/web_interface/live/login_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/login_live_test.exs
@@ -1,0 +1,114 @@
+defmodule WebInterface.LoginLiveTest do
+  @moduledoc false
+
+  use WebInterface.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mock
+
+  alias Shared.Data.{Credentials, User}
+  alias WebInterface.Persistence.User, as: UserStore
+  alias Manager
+
+  describe "frontend events" do
+    test "it submits login without remember-me and calls Manager.login/2 with false", %{conn: conn} do
+      with_mocks([
+        {UserStore, [], [has_user?: fn -> false end]},
+        {Manager, [], [login: fn _login_credentials, _remember_me -> :ok end]}
+      ]) do
+        credentials = Credentials.new("fl4m3@example.com", "hunter2")
+
+        {:ok, view, _html} = live(conn, ~p"/login")
+
+        html =
+          view
+          |> form("#login_form", %{"email" => credentials.email, "password" => credentials.password})
+          |> render_submit()
+
+        assert_called(UserStore.has_user?())
+        assert_called(Manager.login(credentials, false))
+        assert html =~ "Logging in..."
+      end
+    end
+
+    test "it submits login with remember-me and calls Manager.login/2 with true", %{conn: conn} do
+      with_mocks([
+        {UserStore, [], [has_user?: fn -> false end]},
+        {Manager, [],
+         [
+           login: fn _login_credentials, _remember_me ->
+             :ok
+           end
+         ]}
+      ]) do
+        credentials = Credentials.new("fl4m3@example.com", "hunter2")
+
+        {:ok, view, _html} = live(conn, ~p"/login")
+
+        html =
+          view
+          |> form("#login_form", %{
+            "email" => credentials.email,
+            "password" => credentials.password,
+            "remember-me" => ""
+          })
+          |> render_submit()
+
+        assert_called(UserStore.has_user?())
+        assert_called(Manager.login(credentials, true))
+        assert html =~ "Logging in..."
+      end
+    end
+  end
+
+  describe "backend events" do
+    test "it renders the login form", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/login")
+
+      assert html =~ "Sign into your warframe.market account"
+      assert html =~ "Email address"
+      assert html =~ "Password"
+    end
+
+    test "it stores the user and redirects after a successful login", %{conn: conn} do
+      with_mock UserStore,
+        set_user: fn _user -> :ok end,
+        has_user?: fn -> false end do
+        {:ok, view, _html} = live(conn, ~p"/login")
+
+        user = User.new(ingame_name: "Fl4m3", slug: "fl4m3", patreon?: false)
+
+        send(view.pid, {:login, {:ok, user}})
+
+        assert_called(UserStore.set_user(user))
+        assert_redirect(view, ~p"/activate")
+      end
+    end
+
+    for {error, message} <- [
+          {:econnrefused, "Unable to connect to warframe.market. Please verify your internet connection."},
+          {:wrong_password, "Incorrect Password!"},
+          {:wrong_email, "Your email is incorrect or does not exist!"},
+          {:invalid_email, "Please provide a valid email!"},
+          {:timeout, "The request timed out, try again later!"},
+          {:unknown_error, "An unknown error occurred, please report it!"}
+        ] do
+      test "it shows the expected flash for #{error}", %{conn: conn} do
+        {:ok, view, _html} = live(conn, ~p"/login")
+
+        send(view.pid, {:login, {:error, unquote(error)}})
+
+        assert render(view) =~ unquote(message)
+      end
+    end
+
+    @tag capture_log: true
+    test "it shows the fallback flash for an unhandled login error", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/login")
+
+      send(view.pid, {:login, {:error, :request_failed}})
+
+      assert render(view) =~ "Unknown message received, please check the logs and report it!"
+    end
+  end
+end

--- a/apps/web_interface/test/web_interface/live/login_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/login_live_test.exs
@@ -80,8 +80,9 @@ defmodule WebInterface.LoginLiveTest do
 
         send(view.pid, {:login, {:ok, user}})
 
-        assert_called(UserStore.set_user(user))
+        assert_called(UserStore.has_user?())
         assert_redirect(view, ~p"/activate")
+        assert_called(UserStore.set_user(user))
       end
     end
 

--- a/apps/web_interface/test/web_interface/live/login_live_test.exs
+++ b/apps/web_interface/test/web_interface/live/login_live_test.exs
@@ -6,9 +6,9 @@ defmodule WebInterface.LoginLiveTest do
   import Phoenix.LiveViewTest
   import Mock
 
+  alias Manager
   alias Shared.Data.{Credentials, User}
   alias WebInterface.Persistence.User, as: UserStore
-  alias Manager
 
   describe "frontend events" do
     test "it submits login without remember-me and calls Manager.login/2 with false", %{conn: conn} do


### PR DESCRIPTION
- Standardized error messages from manager, so now they all have the correct format
- Fixed an issue where :no_slots_available would desync the BE and FE states
- Fixed FE not handling :no_slots_available scenario properly
- Fixed FE not resetting the UI properly when receiving an error from BE
- Fixed a typo in the products list that would create a request to a non-existing product and cause an error
- Added tests to FE
- Fixed several FE bugs and issues on the login, activate and deactivate flows